### PR TITLE
Fix module import

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ git clone https://github.com/kirklewis/go-template-processing.git
 
 cd go-template-processing
 
-export GOPATH=$PWD
-
 go run main.go
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/kirklewis/go-template-processing
+
+go 1.16

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"demo/template"
 	"fmt"
+	"github.com/kirklewis/go-template-processing/src/demo/template"
 )
 
 func main() {

--- a/tests/process_test.go
+++ b/tests/process_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	"demo/template"
+	"github.com/kirklewis/go-template-processing/src/demo/template"
 )
 
 var vars = map[string]string{


### PR DESCRIPTION
I was having some trouble getting this working.

The guys in #go-nuts @ libera.chat said that this code predated widespread module usage and:

> while there are relative imports in Go, most of the time it's not something you should be using. In practice, import paths are either 
>
> 1. a package in stdlib (path relative to its root in stdlib),
> 2. a package in a module prefixed with the module name, or
> 3. a package name relative to $GOPATH/src/ (but this is on the way out, in favour of modules)

I found their solution worked though.